### PR TITLE
Change console log to warn for offline mode

### DIFF
--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -112,7 +112,7 @@ function checkValidServiceWorker(swUrl, config) {
       }
     })
     .catch(() => {
-      console.log(
+      console.warn(
         'No internet connection found. App is running in offline mode.'
       );
     });


### PR DESCRIPTION
As part of the effort to clean up console.log statements in all the Financial App repos, this console.log is converted to console.warn for consistency and clarity.